### PR TITLE
Proxy forwards requests to backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PROXY_SRC = $(wildcard signer/*.go)
+PROXY_SRC = $(wildcard proxy/*.go)
 CLIENT_SRC = $(wildcard client/*.go)
 SERVER_SRC = $(wildcard server/*.go)
 

--- a/client/main.go
+++ b/client/main.go
@@ -75,24 +75,23 @@ func connectProxy(finished chan bool, post, sockPath, uri string) {
 		},
 	}
 
+	//fullURI := "http://unix" + uri
+	fullURI := "http://localhost:9994" + uri
+
 	delay := 100
 	num := 3
-
 	for i := 0; i <= num; i++ {
-		backoff := backoff(delay, i)
-		fmt.Printf("delay: %v\n", backoff)
-		time.Sleep(backoff)
+		time.Sleep(backoff(delay, i))
 		if len(post) == 0 {
-			response, err = client.Get("http://unix" + uri)
+			response, err = client.Get(fullURI)
 		} else {
-			response, err = client.Post("http://unix"+uri, "application/octet-stream", strings.NewReader(post))
+			response, err = client.Post(fullURI, "application/octet-stream", strings.NewReader(post))
 		}
 
 		if err != nil {
-			fmt.Printf("Error connecting to the socket %s: %v\n", "http://unix"+uri, err)
-			if i == num {
-				os.Exit(1)
-			}
+			fmt.Printf("Error connecting to the socket %s: %v\n", fullURI, err)
+		} else {
+			break
 		}
 	}
 

--- a/server/main.go
+++ b/server/main.go
@@ -24,6 +24,7 @@ func main() {
 
 	server := http.Server{
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Printf("Received request for %q\n", html.EscapeString(r.URL.Path))
 			fmt.Fprintf(w, "Hello, %q", html.EscapeString(r.URL.Path))
 		}),
 	}


### PR DESCRIPTION
- When proxy receives an http request, it creates uses the default
transport and calls RoundTrip to send the response to the destination.
- This works for http, but not for HTTP connect and protocols that
require tunneling.